### PR TITLE
Player respawn system

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -46,9 +46,10 @@ GameObject:
   - component: {fileID: 181471919857712159}
   - component: {fileID: 4753662314636085619}
   - component: {fileID: 3531203726762288711}
+  - component: {fileID: 885664144207347839}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -206,6 +207,34 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 8
   horizontalRayVerticalOffset: 0.05
+  verticalRayHorizontalOffset: 0.05
+--- !u!50 &885664144207347839
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6362461571007744004}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 0
 --- !u!1001 &8203031729276663905
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerMovementSystem/PlayerMovementMotor.cs
+++ b/Assets/Scripts/PlayerMovementSystem/PlayerMovementMotor.cs
@@ -1,3 +1,4 @@
+using PlayerRespawnSystem;
 using UnityEngine;
 
 namespace PlayerMovementSystem
@@ -78,6 +79,9 @@ namespace PlayerMovementSystem
         {
             _input = GetComponent<PlayerInputController>();
             _collisionResolver = GetComponent<PlayerCollisionResolver>();
+            
+            // Register this player as the player to respawn
+            PlayerRespawnManager.Instance.RegisterPlayer(transform);
         }
         
         private void Update()

--- a/Assets/Scripts/PlayerRespawnSystem.meta
+++ b/Assets/Scripts/PlayerRespawnSystem.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 33e4dc46a12a45f6907494bd5f409101
+timeCreated: 1776278243

--- a/Assets/Scripts/PlayerRespawnSystem/Checkpoint.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/Checkpoint.cs
@@ -1,0 +1,61 @@
+using GameState.Core;
+using UnityEngine;
+
+namespace PlayerRespawnSystem
+{
+    /// <summary>
+    /// This is to live on a checkpoint GameObject. It is required to have a BoxCollider2D, with IsTrigger enabled.
+    ///
+    /// When player collider triggers this GameObject's collider, it will set the current Checkpoint
+    /// in GameData to this checkpointIndex, and tell the PlayerRespawnManager this is the respawn point.
+    ///
+    /// The idea is that the "start" of a level should be "0" and increments from there.
+    ///
+    /// When loading, it should read what is the current level, what is the current checkpoint index,
+    /// and spawn the player object there.
+    /// </summary>
+    [RequireComponent(typeof(BoxCollider2D))]
+    public class Checkpoint : MonoBehaviour
+    {
+        [Header("Checkpoint Index")]
+        [SerializeField] private int checkpointIndex;
+        
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!other.CompareTag("Player"))
+                return;
+            
+            // set this checkpoint as respawn point
+            PlayerRespawnManager.Instance.SetCheckpoint(transform.position);
+            
+            // tell GameState this is the new active checkpoint
+            GameStateManager.Instance.SetCheckpoint(checkpointIndex);
+        }
+
+        /// <summary>
+        /// This validates that the checkpoint's BoxCollider IsTrigger is set to true
+        /// Also Logs an Error if two or more checkpoints in this scene share the same checkpoint index value
+        /// </summary>
+        private void OnValidate()
+        {
+            if (!Application.isEditor || Application.isPlaying)
+                return;
+            
+            BoxCollider2D box = GetComponent<BoxCollider2D>();
+            if (box != null && !box.isTrigger)
+                box.isTrigger = true;
+            
+            Checkpoint[] allCheckpoints = FindObjectsByType<Checkpoint>(FindObjectsSortMode.None);
+            foreach (Checkpoint checkpoint in allCheckpoints)
+            {
+                if (checkpoint == this)
+                    continue;
+
+                if (checkpoint.checkpointIndex == checkpointIndex)
+                {
+                    Debug.LogError($"Duplicate checkpoint index detected: {checkpointIndex} on '{name}' and '{checkpoint.name}'");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PlayerRespawnSystem/Checkpoint.cs.meta
+++ b/Assets/Scripts/PlayerRespawnSystem/Checkpoint.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6e82cda97b264993985ce7c16530e092
+timeCreated: 1776278305

--- a/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+namespace PlayerRespawnSystem
+{
+    /// <summary>
+    /// DeathLine creates a really long box collider that when the player triggers
+    /// it calls the PlayerRespawnManager to respawn the player.
+    /// </summary>
+    [RequireComponent(typeof(BoxCollider2D))]
+    public class DeathLine : MonoBehaviour
+    {
+        private const float Width = 9999f;
+        private const float Height = 1f;
+
+        /// <summary>
+        /// If you click reset in inspector : this ensures the collider is re-sized
+        /// </summary>
+        private void Reset()
+        {
+            SetupCollider();
+        }
+
+        /// <summary>
+        /// on validate event cycle ensures collider is proper sized
+        /// </summary>
+        private void OnValidate()
+        {
+            if (!Application.isEditor || Application.isPlaying)
+                return;
+
+            SetupCollider();
+        }
+
+        /// <summary>
+        /// Ensures Collider is proper sized
+        /// </summary>
+        private void SetupCollider()
+        {
+            BoxCollider2D box = GetComponent<BoxCollider2D>();
+            box.isTrigger = true;
+            
+            box.size = new Vector2(Width, Height);
+            box.offset = Vector2.zero;
+        }
+
+        /// <summary>
+        /// This gets called when the collider is triggered
+        /// If it is the player that triggers this, it calls RespawnPlayer operation
+        /// </summary>
+        /// <param name="other"></param>
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!other.CompareTag("Player"))
+                return;
+            
+            PlayerRespawnManager.Instance.RespawnPlayer();
+        }
+    }
+}

--- a/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs.meta
+++ b/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c11c183baa8d427180ca33f310f63116
+timeCreated: 1776283136

--- a/Assets/Scripts/PlayerRespawnSystem/Editor.meta
+++ b/Assets/Scripts/PlayerRespawnSystem/Editor.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 81059c97bfb3497b90a255440e955c79
+timeCreated: 1776281457

--- a/Assets/Scripts/PlayerRespawnSystem/Editor/PlayerRespawnManagerEditor.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/Editor/PlayerRespawnManagerEditor.cs
@@ -1,0 +1,34 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace PlayerRespawnSystem.Editor
+{
+    /// <summary>
+    /// An editor tool attached to the PlayerRespawnManager
+    /// Calls the RespawnPlayer operation from the editor
+    /// </summary>
+    [CustomEditor(typeof(PlayerRespawnManager))]
+    public class PlayerRespawnManagerEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+            
+            EditorGUILayout.Space();
+            
+            PlayerRespawnManager manager = (PlayerRespawnManager)target;
+            
+            if (GUILayout.Button("Respawn Player"))
+            {
+                if (Application.isPlaying)
+                {
+                    manager.RespawnPlayer();
+                }
+                else
+                {
+                    Debug.LogWarning("RespawnPlayer can only be triggered in Play Mode.");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PlayerRespawnSystem/Editor/PlayerRespawnManagerEditor.cs.meta
+++ b/Assets/Scripts/PlayerRespawnSystem/Editor/PlayerRespawnManagerEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 97d9bcdff58f4c478855dedf15469e1b
+timeCreated: 1776281473

--- a/Assets/Scripts/PlayerRespawnSystem/PlayerRespawnManager.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/PlayerRespawnManager.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using Utilities;
+
+namespace PlayerRespawnSystem
+{
+    public class PlayerRespawnManager : PersistentSingleton<PlayerRespawnManager>
+    {
+        private Vector3 _currentCheckpoint;
+        private Transform _playerTransform;
+
+        /// <summary>
+        /// This is the core of this script we interact with.
+        ///
+        /// Upon death (0 life) or missing a jump and triggering some death line,
+        /// this operation should be called.
+        /// </summary>
+        public void RespawnPlayer()
+        {
+            if (_playerTransform == null)
+            {
+                Debug.LogError("[Respawn Manager]: No player transform assigned for respawn");
+                return;
+            }
+            _playerTransform.position = _currentCheckpoint;
+        }
+        
+        /// <summary>
+        /// This is auto-used by the player in PlayerMovementMotor script
+        /// </summary>
+        /// <param name="playerTransform"></param>
+        public void RegisterPlayer(Transform playerTransform)
+        {
+            _playerTransform = playerTransform;
+        }
+
+        /// <summary>
+        /// This is auto used by Checkpoints when they are triggered by the player
+        /// </summary>
+        /// <param name="checkpoint"></param>
+        public void SetCheckpoint(Vector3 checkpoint)
+        {
+            _currentCheckpoint = checkpoint;
+        }
+    }
+}

--- a/Assets/Scripts/PlayerRespawnSystem/PlayerRespawnManager.cs.meta
+++ b/Assets/Scripts/PlayerRespawnSystem/PlayerRespawnManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b63458f32b3142ee84aa7b09c0a9ec94
+timeCreated: 1776277859


### PR DESCRIPTION
Added Player Respawn System

Core: PlayerRespawnManager - holds the operation for respawning the player at a checkpoint 
Notes: Player auto registers within MovementSystem, Checkpoints set upon being triggered

Checkpoint : To live on a checkpoint GameObject, when triggered by player, sets as the active respawn point

DeathLine : A 9999f wide and 1f high collider to be placed at a Y value below level so that when triggered calls the respawn player operation

Further Notes : PlayerRespawnManager also has a editor button added that allows manually calling RespawnPlayer operation.