### PR TITLE
Feat/game state manager updates

### DIFF
--- a/Assets/Scripts/CoinManagement.meta
+++ b/Assets/Scripts/CoinManagement.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e1d5a217e02a44309de99bd19d34fb38
+timeCreated: 1776300959

--- a/Assets/Scripts/CoinManagement/Coin.cs
+++ b/Assets/Scripts/CoinManagement/Coin.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+namespace CoinManagement
+{
+    /// <summary>
+    /// This represents a Coin collectible, it must have a Collider2D for player to trigger
+    ///
+    /// id represents a unique guid identifier for this particular GameObject
+    /// Value represents the points player receives when collecting the coin 
+    /// </summary>
+    [RequireComponent(typeof(CircleCollider2D))]
+    public class Coin : MonoBehaviour
+    {
+        [SerializeField] private CoinId id;
+        [SerializeField] private int value = 1;
+
+        public CoinId Id => id;
+        public int Value => value;
+
+        /// <summary>
+        /// This is called by the CoinManager, when the collection operation has terminated
+        /// </summary>
+        public void Collect()
+        {
+            gameObject.SetActive(false);
+        }
+
+        /// <summary>
+        /// This is called by the CoinManager, when the coin needs to be collectable again
+        /// </summary>
+        public void Respawn()
+        {
+            gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// This is called when the Player triggers the coin object
+        /// </summary>
+        /// <param name="other"></param>
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!other.CompareTag("Player"))
+                return;
+
+            CoinManager.Instance.CollectCoin(this);
+        }
+        
+        /// <summary>
+        /// This is a Unity Editor Event Function ensuring the collider exists, and is a trigger
+        /// It also ensures that if the id value should change, that unity records this change.
+        ///
+        /// This helps so duplicating a coin GameObject ensures the new id is properly updated with Unity
+        /// </summary>
+        private void OnValidate()
+        {
+            if (!Application.isEditor || Application.isPlaying)
+                return;
+            
+            if (string.IsNullOrEmpty(id.Value))
+            {
+                id = CoinId.New();
+                // ensure Unity saves any update to this value
+#if UNITY_EDITOR
+                UnityEditor.EditorUtility.SetDirty(this);
+#endif
+            }
+            
+            CircleCollider2D circle = GetComponent<CircleCollider2D>();
+            if (circle != null)
+            {
+                if (!circle.isTrigger)
+                    circle.isTrigger = true;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/CoinManagement/Coin.cs.meta
+++ b/Assets/Scripts/CoinManagement/Coin.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c8501ee1074f4faa83794aae21dce8d0
+timeCreated: 1776300971

--- a/Assets/Scripts/CoinManagement/CoinId.cs
+++ b/Assets/Scripts/CoinManagement/CoinId.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace CoinManagement
+{
+    /// <summary>
+    /// This defines a unique id for each coin. Making every coin game object uniquely identifiable.
+    /// </summary>
+    [Serializable]
+    public readonly struct CoinId : IEquatable<CoinId>
+    {
+        public readonly string Value;
+        
+        private CoinId(string value) => Value = value;
+
+        public static CoinId New() => new(Guid.NewGuid().ToString());
+        
+        public bool Equals(CoinId other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is CoinId other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+        public override string ToString() => Value;
+    }
+}

--- a/Assets/Scripts/CoinManagement/CoinId.cs.meta
+++ b/Assets/Scripts/CoinManagement/CoinId.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11cf1a82fec840bb847eadcb4a41ce28
+timeCreated: 1776300977

--- a/Assets/Scripts/CoinManagement/CoinManager.cs
+++ b/Assets/Scripts/CoinManagement/CoinManager.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using GameState.Core;
+using Utilities;
+
+namespace CoinManagement
+{
+    /// <summary>
+    /// This single handles tracking Coin Management. When a Coin is collected,
+    /// it is added to a list of collected since last checkpoint,
+    /// if they player should not reach another checkpoint prior to death,
+    /// Coin Manager handles refreshing these coins, and removing them from data.
+    /// Should the player reach a checkpoint, Coin Manager refreshes the list,
+    /// keeping those coins in a permanently collected state.
+    /// </summary>
+    public class CoinManager : PersistentSingleton<CoinManager>
+    {
+        private readonly List<Coin> _collectedSinceCheckpoint = new();
+        private int _coinTotalValueSinceCheckpoint;
+
+        /// <summary>
+        /// This to be called by the coin when it is collected
+        /// </summary>
+        /// <param name="coin"></param>
+        public void CollectCoin(Coin coin)
+        {
+            GameStateManager.Instance.AddCoin(coin.Value);
+            GameStateManager.Instance.AddLevelCoin(coin.Value);
+            
+            _collectedSinceCheckpoint.Add(coin);
+            _coinTotalValueSinceCheckpoint += coin.Value;
+            
+            coin.Collect();
+        }
+
+        /// <summary>
+        /// This is called by GameFlowManager when the coins are to be refreshed upon a death
+        /// </summary>
+        public void RespawnCoins()
+        {
+            GameStateManager.Instance.AddCoin(-_coinTotalValueSinceCheckpoint);
+            GameStateManager.Instance.AddLevelCoin(-_coinTotalValueSinceCheckpoint);
+            
+            foreach (Coin coin in _collectedSinceCheckpoint)
+                coin.Respawn();
+            
+            _collectedSinceCheckpoint.Clear();
+            _coinTotalValueSinceCheckpoint = 0;
+        }
+
+        /// <summary>
+        /// This to be called by GameFlowManager, when a Checkpoint has been reached
+        /// </summary>
+        public void ReachedCheckpoint()
+        {
+            _collectedSinceCheckpoint.Clear();
+            _coinTotalValueSinceCheckpoint = 0;
+        }
+    }
+}

--- a/Assets/Scripts/CoinManagement/CoinManager.cs.meta
+++ b/Assets/Scripts/CoinManagement/CoinManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c98bf7ad6baf4b52952d20d9569b9f24
+timeCreated: 1776300984

--- a/Assets/Scripts/GameState/Core/GameData.cs
+++ b/Assets/Scripts/GameState/Core/GameData.cs
@@ -14,15 +14,19 @@ namespace GameState.Core
         
         public int PlayerHealth { get; internal set; }
         public int MaxHealth { get; internal set; }
+        public int TotalDeaths { get; internal set; }
         
-        public LevelId CurrentLevel { get; internal set; }
+        public string CurrentLevel { get; internal set; }
         public PlayerId CurrentPlayer { get; internal set; }
 
         public int CurrentCheckpoint { get; internal set; }
         public int Coins { get; internal set; }
 
-        public HashSet<LevelId> LevelsUnlocked { get; internal set; } = new();
-        public HashSet<LevelId> LevelsCompleted { get; internal set; } = new();
+        public HashSet<string> LevelsUnlocked { get; internal set; } = new();
+        public HashSet<string> LevelsCompleted { get; internal set; } = new();
+
+        // string is the scene name associated with the corresponding level data
+        public Dictionary<string, LevelData> LevelStats { get; internal set; } = new();
 
         // constructor
         

--- a/Assets/Scripts/GameState/Core/GameData.cs
+++ b/Assets/Scripts/GameState/Core/GameData.cs
@@ -20,7 +20,7 @@ namespace GameState.Core
         public PlayerId CurrentPlayer { get; internal set; }
 
         public int CurrentCheckpoint { get; internal set; }
-        public int Coins { get; internal set; }
+        public int TotalCoins { get; internal set; }
 
         public HashSet<string> LevelsUnlocked { get; internal set; } = new();
         public HashSet<string> LevelsCompleted { get; internal set; } = new();

--- a/Assets/Scripts/GameState/Core/GameStateManager.cs
+++ b/Assets/Scripts/GameState/Core/GameStateManager.cs
@@ -14,10 +14,10 @@ namespace GameState.Core
     {
         public GameData Data { get; private set; }
         
-        protected override void Awake()
-        {
-            base.Awake();
-        }
+        private float _levelStartTime;
+        private int _levelCoins;
+        private int _levelDeaths;
+        private int _maxCoinsInLevel;
         
         public void SetActiveData(GameData data)
         {
@@ -26,7 +26,7 @@ namespace GameState.Core
         
         // GameState mutation operations
         
-        public void AddCoin(int amount = 1)
+        public void AddCoin(int amount)
         {
             Data.Coins += amount;
         }
@@ -36,17 +36,22 @@ namespace GameState.Core
             Data.PlayerHealth = Mathf.Max(0, Data.PlayerHealth - amount);
         }
 
-        public void UnlockLevel(LevelId levelId)
+        public void AddDeath()
+        {
+            Data.TotalDeaths++;
+        }
+
+        public void UnlockLevel(string levelId)
         {
             Data.LevelsUnlocked.Add(levelId);
         }
 
-        public void CompleteLevel(LevelId levelId)
+        public void CompleteLevel(string levelId)
         {
             Data.LevelsCompleted.Add(levelId);
         }
 
-        public void SetCurrentLevel(LevelId levelId)
+        public void SetCurrentLevel(string levelId)
         {
             Data.CurrentLevel = levelId;
         }
@@ -60,5 +65,64 @@ namespace GameState.Core
         {
             Data.CurrentCheckpoint = checkpointIndex;
         }
+        
+        // Per level data updates
+
+        public void BeginLevel(string sceneName, int maxCoins)
+        {
+            if (Data == null)
+            {
+                Debug.LogWarning("GameState Manager is missing Data");
+                return;
+            }
+
+            Data.CurrentLevel = sceneName;
+            
+            _levelStartTime = Time.time;
+            _levelCoins = 0;
+            _levelDeaths = 0;
+            _maxCoinsInLevel = maxCoins;
+        }
+        
+        public void AddLevelCoin(int amount)
+        {
+            _levelCoins += amount;
+        }
+
+        public void AddLevelDeath()
+        {
+            _levelDeaths++;
+        }
+
+        public void SaveCurrentLevelProgress()
+        {
+            if (Data == null)
+                return;
+            
+            string level = Data.CurrentLevel;
+            float time = Time.time - _levelStartTime;
+
+            LevelData snapshot = new(
+                time: time,
+                coins: _levelCoins,
+                deaths: _levelDeaths
+            );
+            
+            Data.LevelStats[level] = snapshot;
+        }
+
+        public LevelData EndLevel()
+        {
+            float time = Time.time - _levelStartTime;
+
+            return new LevelData(
+                time: time,
+                coins: _levelCoins,
+                deaths: _levelDeaths
+            );
+        }
+        
+        public int GetMaxCoinsInLevel() => _maxCoinsInLevel;
+
     }
 }

--- a/Assets/Scripts/GameState/Core/GameStateManager.cs
+++ b/Assets/Scripts/GameState/Core/GameStateManager.cs
@@ -9,6 +9,9 @@ namespace GameState.Core
     /// Responsibilities:
     ///     Provide safe mutation operations for gameplay systems
     ///     Enforce some domain invariants (like maxHealth >= health >= 0)
+    ///
+    /// Note that mutation here does not mean the data is saved. This mutates the data,
+    /// SaveLoadSystem saves the data
     /// </summary>
     public class GameStateManager : PersistentSingleton<GameStateManager>
     {

--- a/Assets/Scripts/GameState/Core/GameStateManager.cs
+++ b/Assets/Scripts/GameState/Core/GameStateManager.cs
@@ -28,7 +28,7 @@ namespace GameState.Core
         
         public void AddCoin(int amount)
         {
-            Data.Coins += amount;
+            Data.TotalCoins += amount;
         }
 
         public void TakeDamage(int amount)

--- a/Assets/Scripts/GameState/Core/LevelId.cs
+++ b/Assets/Scripts/GameState/Core/LevelId.cs
@@ -2,6 +2,10 @@
 
 namespace GameState.Core
 {
+    /// <summary>
+    /// This is replaced with the string identifier for a scene name
+    /// </summary>
+    [Obsolete]
     public readonly struct LevelId : IEquatable<LevelId>
     {
         public readonly string Value;

--- a/Assets/Scripts/GameState/Editor/GameFlowManagerEditor.cs
+++ b/Assets/Scripts/GameState/Editor/GameFlowManagerEditor.cs
@@ -1,0 +1,39 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace GameState.Editor
+{
+    [CustomEditor(typeof(GameFlowManager))]
+    public class GameFlowManagerEditor : UnityEditor.Editor
+    {
+        private string _sceneName;
+
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+            
+            EditorGUILayout.Space();
+            
+            _sceneName = EditorGUILayout.TextField("Scene Name", _sceneName);
+            
+            if (Application.isPlaying)
+            {
+                if (GUILayout.Button("Trigger OnLevelStarted"))
+                {
+                    GameFlowManager manager = (GameFlowManager)target;
+                    manager.SendMessage("OnLevelStarted", _sceneName);
+                }
+                
+                if (GUILayout.Button("Trigger Player Death"))
+                {
+                    GameFlowManager manager = (GameFlowManager)target;
+                    manager.SendMessage("OnPlayerDeath");
+                }
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("Enter Play Mode to use debug tools.", MessageType.Info);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GameState/Editor/GameFlowManagerEditor.cs.meta
+++ b/Assets/Scripts/GameState/Editor/GameFlowManagerEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d7908b978e0b453092d233cf0d700bf0
+timeCreated: 1776311942

--- a/Assets/Scripts/GameState/GameFlowManager.cs
+++ b/Assets/Scripts/GameState/GameFlowManager.cs
@@ -1,0 +1,79 @@
+using CoinManagement;
+using GameState.Core;
+using GameState.SaveLoad;
+using PlayerRespawnSystem;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Utilities;
+
+namespace GameState
+{
+    /// <summary>
+    /// Central Flow Manager
+    ///
+    /// This is in place of events being published, as a particular sequence of events must happen.
+    /// </summary>
+    public class GameFlowManager : PersistentSingleton<GameFlowManager>
+    {
+        protected override void Awake()
+        {
+            base.Awake();
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        /// <summary>
+        /// This is called when SceneManager triggers the event for a SceneLoading event.
+        /// It skips any scenes that are not a level
+        /// GameFlowManager then initiates the level data start up sequence for the level
+        /// </summary>
+        /// <param name="scene"></param>
+        /// <param name="sceneMode"></param>
+        private void OnSceneLoaded(Scene scene, LoadSceneMode sceneMode)
+        {
+            if (!scene.name.StartsWith("Level"))
+                return;
+            
+            OnLevelStarted(scene.name);
+        }
+
+        private void OnLevelStarted(string sceneName)
+        {
+            // counts the total number of coin objects in the scene at the start of the scene
+            int maxCoins = FindObjectsByType<Coin>(FindObjectsSortMode.None).Length;
+            
+            GameStateManager.Instance.BeginLevel(sceneName, maxCoins);
+        }
+
+        /// <summary>
+        /// Call This when a checkpoint is reached,
+        /// GameFlowManager handles the operation order that must occur
+        /// </summary>
+        /// <param name="checkpointIndex"></param>
+        /// <param name="checkpointPosition"></param>
+        public static void OnCheckpointReached(int checkpointIndex, Vector3 checkpointPosition)
+        {
+            GameStateManager.Instance.SetCheckpoint(checkpointIndex);
+            
+            PlayerRespawnManager.Instance.SetCheckpoint(checkpointPosition);
+            
+            CoinManager.Instance.ReachedCheckpoint();
+            
+            SaveLoadSystem.Instance.SaveGame();
+        }
+
+        /// <summary>
+        /// Call this when the player has died: FlowManager handles the operation order that must occur to keep data safe
+        /// </summary>
+        public void OnPlayerDeath()
+        {
+            GameStateManager.Instance.AddLevelDeath();
+            GameStateManager.Instance.AddDeath();
+            
+            CoinManager.Instance.RespawnCoins();
+            
+            PlayerRespawnManager.Instance.RespawnPlayer();
+            
+            SaveLoadSystem.Instance.SaveGame();
+        }
+    }
+}

--- a/Assets/Scripts/GameState/GameFlowManager.cs.meta
+++ b/Assets/Scripts/GameState/GameFlowManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 40e8553446764efba6bfdce2685e4570
+timeCreated: 1776303961

--- a/Assets/Scripts/GameState/LevelData.meta
+++ b/Assets/Scripts/GameState/LevelData.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9380b9d70132422da7895caadf689ca1
+timeCreated: 1776304960

--- a/Assets/Scripts/GameState/LevelData/LevelData.cs
+++ b/Assets/Scripts/GameState/LevelData/LevelData.cs
@@ -1,0 +1,36 @@
+namespace GameState
+{
+    /// <summary>
+    /// Represents the Data within a particular level.
+    /// Time (WIP)
+    /// Coins, the amount of coins collected within this level
+    /// Deaths, the amount of deaths within this level
+    /// </summary>
+    public class LevelData
+    {
+        public readonly float Time;
+        public readonly int Coins;
+        public readonly int Deaths;
+
+        public LevelData(float time, int coins, int deaths)
+        {
+            Time = time;
+            Coins = coins;
+            Deaths = deaths;
+        }
+
+        /// <summary>
+        /// eventually to be used to calculate a score at the end of the game
+        /// </summary>
+        /// <param name="maxCoins"></param>
+        /// <returns></returns>
+        public float ComputeScore(int maxCoins)
+        {
+            float coinScore = (float)Coins / maxCoins;
+            float deathScore = 1f / (1 + Deaths);
+            float timeScore = 1f / (1 + Time);
+            
+            return coinScore + deathScore * timeScore;
+        }
+    }
+}

--- a/Assets/Scripts/GameState/LevelData/LevelData.cs.meta
+++ b/Assets/Scripts/GameState/LevelData/LevelData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1286299466e6427cb5a600bd12c233e1
+timeCreated: 1776304968

--- a/Assets/Scripts/GameState/LevelData/LevelDataDTO.cs
+++ b/Assets/Scripts/GameState/LevelData/LevelDataDTO.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace GameState
+{
+    [Serializable]
+    public class LevelDataDTO
+    {
+        public string sceneName;
+        public float time;
+        public int coins;
+        public int deaths;
+    }
+}

--- a/Assets/Scripts/GameState/LevelData/LevelDataDTO.cs.meta
+++ b/Assets/Scripts/GameState/LevelData/LevelDataDTO.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b028bcf3edeb453b86ceccafa1fc4101
+timeCreated: 1776306219

--- a/Assets/Scripts/GameState/SaveLoad/GameDataAdapter.cs
+++ b/Assets/Scripts/GameState/SaveLoad/GameDataAdapter.cs
@@ -20,16 +20,18 @@ namespace GameState.SaveLoad
                 playerHealth =  data.PlayerHealth,
                 maxHealth =  data.MaxHealth,
                 
-                currentLevel = data.CurrentLevel.Value,
+                totalDeaths = data.TotalDeaths,
+                
+                currentLevel = data.CurrentLevel,
                 currentPlayer =  data.CurrentPlayer.Value,
                 
                 currentCheckpoint =  data.CurrentCheckpoint,
                 coins = data.Coins,
                 
-                levelsUnlocked = new List<string>(
-                    data.LevelsUnlocked.Select(l => l.Value)),
-                levelsCompleted = new List<string>(
-                    data.LevelsCompleted.Select(l => l.Value)),
+                levelsUnlocked = data.LevelsUnlocked.ToList(),
+                levelsCompleted = data.LevelsCompleted.ToList(),
+                
+                levelStats = ToLevelStatsDTO(data.LevelStats)
             };
         }
 
@@ -40,18 +42,53 @@ namespace GameState.SaveLoad
                 PlayerHealth = dto.playerHealth,
                 MaxHealth = dto.maxHealth,
                 
-                CurrentLevel = new LevelId(dto.currentLevel),
+                TotalDeaths = dto.totalDeaths,
+                
+                CurrentLevel = dto.currentLevel,
                 CurrentPlayer = new PlayerId(dto.currentPlayer),
                 
                 CurrentCheckpoint = dto.currentCheckpoint,
                 Coins = dto.coins,
                 
-                LevelsUnlocked = new HashSet<LevelId>(
-                    dto.levelsUnlocked.Select(id => new LevelId(id))),
-                LevelsCompleted = new HashSet<LevelId>(
-                    dto.levelsCompleted.Select(id => new LevelId(id))),
+                LevelsUnlocked = new HashSet<string>(dto.levelsUnlocked),
+                LevelsCompleted = new HashSet<string>(dto.levelsCompleted),
+                
+                LevelStats = FromLevelStatsDTO(dto.levelStats)
             };
+
             return data;
+        }
+
+        private static List<LevelDataDTO> ToLevelStatsDTO(Dictionary<string, LevelData> dict)
+        {
+            List<LevelDataDTO> list = new();
+
+            foreach (KeyValuePair<string, LevelData> kvp in dict)
+            {
+                list.Add(new LevelDataDTO
+                {
+                    sceneName = kvp.Key,
+                    time =  kvp.Value.Time,
+                    coins = kvp.Value.Coins,
+                    deaths = kvp.Value.Deaths,
+                });
+            }
+            return list;
+        }
+
+        private static Dictionary<string, LevelData> FromLevelStatsDTO(List<LevelDataDTO> list)
+        {
+            Dictionary<string, LevelData> dict = new();
+
+            foreach (LevelDataDTO item in list)
+            {
+                dict[item.sceneName] = new LevelData(
+                    item.time,
+                    item.coins,
+                    item.deaths
+                );
+            }
+            return dict;
         }
     }
 }

--- a/Assets/Scripts/GameState/SaveLoad/GameDataAdapter.cs
+++ b/Assets/Scripts/GameState/SaveLoad/GameDataAdapter.cs
@@ -26,7 +26,7 @@ namespace GameState.SaveLoad
                 currentPlayer =  data.CurrentPlayer.Value,
                 
                 currentCheckpoint =  data.CurrentCheckpoint,
-                coins = data.Coins,
+                totalCoins = data.TotalCoins,
                 
                 levelsUnlocked = data.LevelsUnlocked.ToList(),
                 levelsCompleted = data.LevelsCompleted.ToList(),
@@ -48,7 +48,7 @@ namespace GameState.SaveLoad
                 CurrentPlayer = new PlayerId(dto.currentPlayer),
                 
                 CurrentCheckpoint = dto.currentCheckpoint,
-                Coins = dto.coins,
+                TotalCoins = dto.totalCoins,
                 
                 LevelsUnlocked = new HashSet<string>(dto.levelsUnlocked),
                 LevelsCompleted = new HashSet<string>(dto.levelsCompleted),

--- a/Assets/Scripts/GameState/SaveLoad/GameDataDTO.cs
+++ b/Assets/Scripts/GameState/SaveLoad/GameDataDTO.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEngine.Serialization;
 
 namespace GameState.SaveLoad
 {
@@ -22,7 +23,7 @@ namespace GameState.SaveLoad
         public string currentPlayer;
 
         public int currentCheckpoint;
-        public int coins;
+        public int totalCoins;
 
         public List<string> levelsUnlocked;
         public List<string> levelsCompleted;

--- a/Assets/Scripts/GameState/SaveLoad/GameDataDTO.cs
+++ b/Assets/Scripts/GameState/SaveLoad/GameDataDTO.cs
@@ -15,6 +15,8 @@ namespace GameState.SaveLoad
 
         public int playerHealth;
         public int maxHealth;
+
+        public int totalDeaths;
         
         public string currentLevel;
         public string currentPlayer;
@@ -24,5 +26,7 @@ namespace GameState.SaveLoad
 
         public List<string> levelsUnlocked;
         public List<string> levelsCompleted;
+
+        public List<LevelDataDTO> levelStats;
     }
 }

--- a/Assets/Scripts/GameState/SaveLoad/SaveLoadSystem.cs
+++ b/Assets/Scripts/GameState/SaveLoad/SaveLoadSystem.cs
@@ -23,6 +23,8 @@ namespace GameState.SaveLoad
         /// </summary>
         public void SaveGame()
         {
+            GameStateManager.Instance.SaveCurrentLevelProgress();
+            
             GameData domainData = GameStateManager.Instance.Data;
             
             GameDataDTO dto = GameDataAdapter.ToDTO(domainData);
@@ -69,11 +71,19 @@ namespace GameState.SaveLoad
                 Coins = 0,
                 CurrentCheckpoint = 0,
                 
-                CurrentLevel = LevelId.New(),
+                CurrentLevel = "Level_01",
                 CurrentPlayer = PlayerId.New(),
+                
+                LevelStats =
+                {
+                    // fresh LevelData for level 1 start
+                    ["Level_01"] = new LevelData(
+                        time: 0f,
+                        coins: 0,
+                        deaths: 0
+                    )
+                }
             };
-            
-            //data.LevelsUnlocked.Add(data.CurrentLevel);
 
             GameStateManager.Instance.SetActiveData(data);
             

--- a/Assets/Scripts/GameState/SaveLoad/SaveLoadSystem.cs
+++ b/Assets/Scripts/GameState/SaveLoad/SaveLoadSystem.cs
@@ -68,7 +68,7 @@ namespace GameState.SaveLoad
             {
                 PlayerHealth = 3,
                 MaxHealth = 5,
-                Coins = 0,
+                TotalCoins = 0,
                 CurrentCheckpoint = 0,
                 
                 CurrentLevel = "Level_01",

--- a/Assets/Scripts/PlayerRespawnSystem/Checkpoint.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/Checkpoint.cs
@@ -1,3 +1,4 @@
+using GameState;
 using GameState.Core;
 using UnityEngine;
 
@@ -25,11 +26,7 @@ namespace PlayerRespawnSystem
             if (!other.CompareTag("Player"))
                 return;
             
-            // set this checkpoint as respawn point
-            PlayerRespawnManager.Instance.SetCheckpoint(transform.position);
-            
-            // tell GameState this is the new active checkpoint
-            GameStateManager.Instance.SetCheckpoint(checkpointIndex);
+            GameFlowManager.OnCheckpointReached(checkpointIndex, transform.position);
         }
 
         /// <summary>

--- a/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs
@@ -1,3 +1,4 @@
+using GameState;
 using UnityEngine;
 
 namespace PlayerRespawnSystem
@@ -53,7 +54,7 @@ namespace PlayerRespawnSystem
             if (!other.CompareTag("Player"))
                 return;
             
-            PlayerRespawnManager.Instance.RespawnPlayer();
+            GameFlowManager.Instance.OnPlayerDeath();
         }
     }
 }


### PR DESCRIPTION
I did the thing again. Although now I'm noticing Singleton fatigue. 

Important notes: GameFlowManager is to be used as an event flag. Death "events" should tell GameFlowManager a death occured, and GameFlowManager will handle calling the correct operations in sequence. 

Added a Coin system. So a coin objects with collider that is collectable. It will change data to reflect it is collected, but CoinManager handles collection between checkpoints. A death before reaching a checkpoint will subtract the collected coins, and re-enabled them for collecting again

Level Data was also added. A way to save, for each level, how many death, coins, and time stats for that level. The time is a major WIP, it needs to be done differently, I just did not have time to actually get to that yet.

Please Review and ask questions, there's a lot of changes

This starts to address the coin / scoring system, but does not fully close the issue