### PR TITLE
Arrow Bugfix

### DIFF
--- a/Assets/Scripts/PlayerHazards/ArrowHazard.cs
+++ b/Assets/Scripts/PlayerHazards/ArrowHazard.cs
@@ -36,7 +36,7 @@ public class ArrowHazard : MonoBehaviour
     {
         if(other.CompareTag("Player"))
         {
-            Destroy(gameObject);
+            Destroy(gameObject, 0.05f);
             return;
         }
         if(!other.isTrigger)


### PR DESCRIPTION
Arrows were not damaging player due to the object being destroyed instantly, just added a small delay so the player hazard script could register the damage.