### PR TITLE
Feat/animation expansion

### DIFF
--- a/Assets/Imports/SPUM/Core/Basic_Resources/Animator/Unit/DEATH.anim
+++ b/Assets/Imports/SPUM/Core/Basic_Resources/Animator/Unit/DEATH.anim
@@ -5428,4 +5428,11 @@ AnimationClip:
     flags: 0
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.6666667
+    functionName: DeathAnimationComplete
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -46,7 +46,6 @@ GameObject:
   - component: {fileID: 181471919857712159}
   - component: {fileID: 4753662314636085619}
   - component: {fileID: 3531203726762288711}
-  - component: {fileID: 1019184496727885341}
   - component: {fileID: 7178563891242913059}
   - component: {fileID: 7566064289590525338}
   m_Layer: 0
@@ -161,7 +160,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerMovementSystem.PlayerMovementMotor
   visual: {fileID: 5095214590177560044}
-  animatorController: {fileID: 1019184496727885341}
+  animatorController: {fileID: 7453497896955804866}
   maxRunSpeed: 8
   runAcceleration: 60
   runDeceleration: 50
@@ -182,6 +181,7 @@ MonoBehaviour:
   airDashUnlocked: 0
   maxCrouchFallTime: 1
   maxAttackChargeTime: 1
+  flashInterval: 0.1
 --- !u!114 &4753662314636085619
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -211,19 +211,6 @@ MonoBehaviour:
     m_Bits: 72
   horizontalRayVerticalOffset: 0.05
   verticalRayHorizontalOffset: 0.05
---- !u!114 &1019184496727885341
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6362461571007744004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8b751de31f48424c84f429c8c30a00a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::PlayerMovementSystem.PlayerAnimationController
-  animator: {fileID: 1179873298749084663}
 --- !u!114 &7178563891242913059
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -241,7 +228,6 @@ MonoBehaviour:
     m_Bits: 64
   damageAmount: 1
   damageCooldown: 2
-  animatorController: {fileID: 1019184496727885341}
 --- !u!50 &7566064289590525338
 Rigidbody2D:
   serializedVersion: 5
@@ -368,13 +354,34 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4271095123032851471, guid: c54b36ee7861c4b41bd1dabf2455160f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7453497896955804866}
   m_SourcePrefab: {fileID: 100100000, guid: c54b36ee7861c4b41bd1dabf2455160f, type: 3}
 --- !u!95 &1179873298749084663 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 7028084264199744406, guid: c54b36ee7861c4b41bd1dabf2455160f, type: 3}
   m_PrefabInstance: {fileID: 8203031729276663905}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &5373638264627264622 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4271095123032851471, guid: c54b36ee7861c4b41bd1dabf2455160f, type: 3}
+  m_PrefabInstance: {fileID: 8203031729276663905}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7453497896955804866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5373638264627264622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b751de31f48424c84f429c8c30a00a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerMovementSystem.PlayerAnimationController
+  animator: {fileID: 1179873298749084663}
 --- !u!224 &6794357822956327935 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3431018974941178782, guid: c54b36ee7861c4b41bd1dabf2455160f, type: 3}

--- a/Assets/Scenes/Level_01.unity
+++ b/Assets/Scenes/Level_01.unity
@@ -1005,6 +1005,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 181471919857712159, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+      propertyPath: animatorController
+      value: 
+      objectReference: {fileID: 249384111}
+    - target: {fileID: 181471919857712159, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+      propertyPath: spriteRenderers.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 238534618436277891, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
       propertyPath: m_LocalPosition.x
       value: -119.46
@@ -1049,11 +1057,42 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 7178563891242913059, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+      propertyPath: animatorController
+      value: 
+      objectReference: {fileID: 249384111}
+    m_RemovedComponents:
+    - {fileID: 1019184496727885341, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5373638264627264622, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 249384111}
   m_SourcePrefab: {fileID: 100100000, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+--- !u!95 &249384109 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 1179873298749084663, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+  m_PrefabInstance: {fileID: 249384108}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &249384110 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5373638264627264622, guid: 2687726a5acd42c40b586fa3fd28938d, type: 3}
+  m_PrefabInstance: {fileID: 249384108}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &249384111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249384110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b751de31f48424c84f429c8c30a00a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerMovementSystem.PlayerAnimationController
+  animator: {fileID: 249384109}
 --- !u!1 &265978184
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameState/Core/GameStateManager.cs
+++ b/Assets/Scripts/GameState/Core/GameStateManager.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using Utilities;
 
 namespace GameState.Core
@@ -17,10 +18,31 @@ namespace GameState.Core
     {
         public GameData Data { get; private set; }
         
+        public event Action OnPlayerDamaged;
+        public event Action OnPlayerInvincibilityStarted;
+        public event Action OnPlayerInvincibilityEnded;
+
+        private float _invincibleTimer;
+        private bool _invincible;
+
+        [SerializeField] private float invincibleDuration = 1.5f;
+
         public string CurrentLevel => Data?.CurrentLevel;
         public int CurrentCheckpoint => Data?.CurrentCheckpoint ?? -1;
         
         public string[] levelOrder = { "Level_01", "Level_02", "Level_03", "Level_04" };
+        
+        private void Update()
+        {
+            if (!_invincible) return;
+
+            _invincibleTimer -= Time.deltaTime;
+
+            if (_invincibleTimer > 0f) return;
+            
+            _invincible = false;
+            OnPlayerInvincibilityEnded?.Invoke();
+        }
         
         public void SetActiveData(GameData data)
         {
@@ -38,7 +60,15 @@ namespace GameState.Core
 
         public void TakeDamage(int amount)
         {
+            if (_invincible) return;
+            
             Data.PlayerHealth = Mathf.Max(0, Data.PlayerHealth - amount);
+            
+            OnPlayerDamaged?.Invoke();
+            
+            _invincible = true;
+            _invincibleTimer = invincibleDuration;
+            OnPlayerInvincibilityStarted?.Invoke();
         }
 
         public void AddDeath()

--- a/Assets/Scripts/GameState/GameFlowManager.cs
+++ b/Assets/Scripts/GameState/GameFlowManager.cs
@@ -23,7 +23,7 @@ namespace GameState
     public class GameFlowManager : PersistentSingleton<GameFlowManager>
     {
         private const string FirstLevelSceneName = "Level_01";
-        // private const string FirstLevelSceneName = "Level_02(TestClone)";
+        private const float RespawnTime = 1f;
 
         // ------------  PUBLIC API OPERATION CALLS ------------
 
@@ -45,9 +45,19 @@ namespace GameState
         }
 
         /// <summary>
-        /// Call this when the player has died: GFM will handle operation sequence.
+        /// Call this when the player has died and should play a death animation
         /// </summary>
         public void OnPlayerDeath()
+        {
+            PlayerControlManager.Instance.FreezeInput();
+            LevelTimer.Instance.StopTimer();
+            PlayerControlManager.Instance.PlayDeathAnimation();
+        }
+
+        /// <summary>
+        /// Calls this when the player has died but needs to respawn immediately
+        /// </summary>
+        public void RespawnPlayer()
         {
             StartCoroutine(PlayerDeathFlow());
         }
@@ -158,7 +168,8 @@ namespace GameState
         private static IEnumerator PlayerDeathFlow()
         {
             // Opt: Lose Control of player
-            PlayerControlManager.Instance.Freeze();
+            PlayerControlManager.Instance.FreezeInput();
+            LevelTimer.Instance.StopTimer();
 
             // 1. Add a death to both level death counter and total deaths counter
             GameStateManager.Instance.AddDeath();
@@ -168,23 +179,26 @@ namespace GameState
 
             // 3. Reset Player Health
             GameStateManager.Instance.Data.PlayerHealth = 3;
-
-            // 4. Respawn the player
-            PlayerRespawnManager.Instance.RespawnPlayer();
-
-            // 5. Save the game state
+            
+            // 4. Save the game state
             SaveLoadSystem.Instance.SaveGame();
 
-            // Opt : regain control of player
-            PlayerControlManager.Instance.Unfreeze();
+            // 5. Respawn the player
+            PlayerRespawnManager.Instance.RespawnPlayer();
+            
+            //yield return new WaitForSeconds(RespawnTime);
 
+            // Opt : regain control of player
+            PlayerControlManager.Instance.UnfreezeInput();
+            LevelTimer.Instance.StartTimer();
+            
             yield break;
         }
 
         private static IEnumerator LevelStartFlow(string sceneName)
         {
             // 1. Freeze control of player
-            PlayerControlManager.Instance.Freeze();
+            PlayerControlManager.Instance.FreezeInput();
             LevelTimer.Instance.HideTimer();
             LevelTimer.Instance.StopTimer();
 
@@ -239,18 +253,20 @@ namespace GameState
                 }
             }
             CoinManager.Instance.ReachedCheckpoint();
-            PlayerRespawnManager.Instance.RespawnPlayer();
             SaveLoadSystem.Instance.SaveGame();
+            PlayerRespawnManager.Instance.RespawnPlayer();
+            
+            //yield return new WaitForSeconds(RespawnTime);
 
             // 5. Enable player control + start timer
-            PlayerControlManager.Instance.Unfreeze();
+            PlayerControlManager.Instance.UnfreezeInput();
             LevelTimer.Instance.ShowTimer();
             LevelTimer.Instance.StartTimer();
         }
 
         private static IEnumerator CompleteLevelFlow()
         {
-            PlayerControlManager.Instance.Freeze();
+            PlayerControlManager.Instance.FreezeInput();
             LevelTimer.Instance.StopTimer();
 
             CoinManager.Instance.ReachedCheckpoint();

--- a/Assets/Scripts/PlayerDamage/PlayerHazardDamage.cs
+++ b/Assets/Scripts/PlayerDamage/PlayerHazardDamage.cs
@@ -1,7 +1,5 @@
 using GameState;
 using GameState.Core;
-using PlayerMovementSystem;
-using PlayerRespawnSystem;
 using UnityEngine;
 
 /* This script serves to detect when the player has come into contact with a hazard and apply damage accordingly.
@@ -21,9 +19,6 @@ public class PlayerHazardDamage : MonoBehaviour
     [Header("Damage Settings")]
     [SerializeField] private int damageAmount = 1;
     [SerializeField] private float damageCooldown = 1f;
-    
-    [Header("Animation")] // added by Nico
-    [SerializeField] private PlayerAnimationController animatorController;
 
     /*   time in seconds for cooldown, 
      *   using this to prevent instant death when a player is on top of something
@@ -68,8 +63,6 @@ public class PlayerHazardDamage : MonoBehaviour
 
         GameStateManager.Instance.TakeDamage(damageAmount);
         _coolDown = damageCooldown;
-        
-        animatorController.PlayDamaged();
 
         Debug.Log($"Player Touched Hazard! Health is now {GameStateManager.Instance.Data.PlayerHealth}");
 

--- a/Assets/Scripts/PlayerMovementSystem/PlayerAnimationController.cs
+++ b/Assets/Scripts/PlayerMovementSystem/PlayerAnimationController.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace PlayerMovementSystem
@@ -5,6 +6,8 @@ namespace PlayerMovementSystem
     public class PlayerAnimationController : MonoBehaviour
     {
         [SerializeField] private Animator animator;
+
+        public event Action OnDeathAnimationComplete;
 
         public void SetMove(bool isMoving)
         {
@@ -24,6 +27,12 @@ namespace PlayerMovementSystem
         public void PlayDeath()
         {
             animator.SetTrigger("4_Death");
+        }
+
+        public void DeathAnimationComplete()
+        {
+            OnDeathAnimationComplete?.Invoke();
+            OnDeathAnimationComplete = null;
         }
     }
 }

--- a/Assets/Scripts/PlayerMovementSystem/PlayerControlManager.cs
+++ b/Assets/Scripts/PlayerMovementSystem/PlayerControlManager.cs
@@ -11,7 +11,12 @@ namespace PlayerMovementSystem
             _motor = motor;
         }
         
-        public void Freeze() => _motor.enabled = false;
-        public void Unfreeze() => _motor.enabled = true;
+        public void FreezeInput() => _motor.LockInput();
+        public void UnfreezeInput() => _motor.UnlockInput();
+        
+        public void PlayDeathAnimation()
+        {
+            _motor.PlayDeathAnimation();
+        }
     }
 }

--- a/Assets/Scripts/PlayerMovementSystem/PlayerMovementMotor.cs
+++ b/Assets/Scripts/PlayerMovementSystem/PlayerMovementMotor.cs
@@ -1,3 +1,6 @@
+using System.Collections;
+using GameState;
+using GameState.Core;
 using PlayerRespawnSystem;
 using UnityEngine;
 
@@ -75,15 +78,30 @@ namespace PlayerMovementSystem
         private bool WasGrounded { get; set; }
 
         private Vector2 Velocity { get; set; }
+
+        private bool InputLocked { get; set; }
+        private bool _nextGroundingUnlocksPlayer;
+        
+        [Header("Invincibility Settings")]
+        [SerializeField] private float flashInterval = 0.1f;
+        private SpriteRenderer[] _allSpriteRenderers;
+        private MaterialPropertyBlock _mpb;
+        private Coroutine _flashRoutine;
         
         private void Awake()
         {
             _input = GetComponent<PlayerInputController>();
             _collisionResolver = GetComponent<PlayerCollisionResolver>();
             
+            _allSpriteRenderers = visual.GetComponentsInChildren<SpriteRenderer>(true);
+            
             // Register this player as the player to respawn
             PlayerRespawnManager.Instance.RegisterPlayer(transform);
             PlayerControlManager.Instance.RegisterMotor(this);
+            
+            GameStateManager.Instance.OnPlayerDamaged += HandleDamage;
+            GameStateManager.Instance.OnPlayerInvincibilityStarted += HandleInvincibilityStart;
+            GameStateManager.Instance.OnPlayerInvincibilityEnded += HandleInvincibilityEnd;
         }
         
         private void Update()
@@ -149,7 +167,13 @@ namespace PlayerMovementSystem
             if (IsGrounded && !WasGrounded)
             {
                 _hasGroundedSinceLastDash = true;
-                
+
+                if (_nextGroundingUnlocksPlayer)
+                {
+                    _nextGroundingUnlocksPlayer = false;
+                    InputLocked = false;
+                }
+
                 if (_isCrouchFalling)
                 {
                     float duration = _crouchFallTimer;
@@ -170,6 +194,8 @@ namespace PlayerMovementSystem
         /// </summary>
         private void HandleJump()
         {
+            if (InputLocked) return;
+            
             // Jump trigger (buffer + coyote)
             if (_jumpBufferCounter > 0 && _coyoteCounter > 0)
             {
@@ -207,6 +233,8 @@ namespace PlayerMovementSystem
         
         private void HandleHorizontalMovement(float dt)
         {
+            if (InputLocked) return;
+            
             // active dash is overriding horizontal movement
             if (_state == DashState.Dashing)
                 return;
@@ -270,6 +298,8 @@ namespace PlayerMovementSystem
         /// </summary>
         private void HandleDash(float dt)
         {
+            if (InputLocked) return;
+            
             // input check
             if (_state == DashState.Normal && dashUnlocked && _input.DashPressed)
             {
@@ -359,6 +389,8 @@ namespace PlayerMovementSystem
         /// <param name="dt"></param>
         private void HandleCrouchFall(float dt)
         {
+            if (InputLocked) return;
+            
             // can't crouch fall from grounded state
             if (IsGrounded)
                 return;
@@ -401,6 +433,8 @@ namespace PlayerMovementSystem
         /// </summary>
         private void HandleAttack()
         {
+            if (InputLocked) return;
+            
             // no attack during crouch fall (crouch fall is an attack)
             if (_isCrouchFalling)
                 return;
@@ -452,7 +486,89 @@ namespace PlayerMovementSystem
                 animatorController.PlayAttack();
             }
         }
+
+        public void PlayDeathAnimation()
+        {
+            LockInput();
+            Velocity = Vector2.zero;
+            
+            animatorController.PlayDeath();
+            animatorController.OnDeathAnimationComplete += HandleDeathAnimationComplete;
+        }
         
+        private void HandleDeathAnimationComplete()
+        {
+            animatorController.OnDeathAnimationComplete -= HandleDeathAnimationComplete;
+            
+            GameFlowManager.Instance.RespawnPlayer();
+        }
+
+        public void LockInput()
+        {
+            InputLocked = true;
+            
+            Velocity = new Vector2(0f, Velocity.y);
+        }
+
+        public void UnlockInput()
+        {
+            if (IsGrounded)
+            {
+                InputLocked = false;
+                _nextGroundingUnlocksPlayer = false;
+                return;
+            }
+
+            _nextGroundingUnlocksPlayer = true;
+        }
+
+        private void HandleDamage()
+        {
+            animatorController.PlayDamaged();
+        }
+        
+        private void HandleInvincibilityStart()
+        {
+            if (_flashRoutine != null)
+                StopCoroutine(_flashRoutine);
+
+            _flashRoutine = StartCoroutine(FlashSprite());
+        }
+
+        private void HandleInvincibilityEnd()
+        {
+            if (_flashRoutine != null)
+                StopCoroutine(_flashRoutine);
+
+            SetSpriteAlpha(1f);
+        }
+        
+        private IEnumerator FlashSprite()
+        {
+            while (true)
+            {
+                SetSpriteAlpha(0.3f);
+                yield return new WaitForSeconds(flashInterval);
+
+                SetSpriteAlpha(1f);
+                yield return new WaitForSeconds(flashInterval);
+            }
+        }
+
+        private void SetSpriteAlpha(float alpha)
+        {
+            _mpb ??= new MaterialPropertyBlock();
+
+            foreach (SpriteRenderer sr in _allSpriteRenderers)
+            {
+                sr.GetPropertyBlock(_mpb);
+                Color c = sr.color;
+                c.a = alpha;
+                _mpb.SetColor("_Color", c);
+                sr.SetPropertyBlock(_mpb);
+            }
+        }
+
         private void OnDrawGizmos()
         {
             if (!Application.isPlaying) return;

--- a/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs
+++ b/Assets/Scripts/PlayerRespawnSystem/DeathLine.cs
@@ -54,7 +54,7 @@ namespace PlayerRespawnSystem
             if (!other.CompareTag("Player"))
                 return;
             
-            GameFlowManager.Instance.OnPlayerDeath();
+            GameFlowManager.Instance.RespawnPlayer();
         }
     }
 }


### PR DESCRIPTION
Had fun

Damage now flickers the sprite as well as damaged anim

Death from damage plays anim, anim publishes event, and respawn from there.

Respawn and death player lock work better (user gains control of player when it is grounded from a respawn)

Invincibility for a time after a damaged event (corresponds directly to the sprite flicker)