### PR TITLE
Patch/level completed "next button" logic patch

### DIFF
--- a/Assets/Scripts/GameState/GameFlowManager.cs
+++ b/Assets/Scripts/GameState/GameFlowManager.cs
@@ -78,6 +78,15 @@ namespace GameState
             StartCoroutine(NewLevelFlow(levelName));
         }
 
+        public void CompleteGame()
+        {
+            Debug.LogError("Complete Game Is Empty : Not Written yet");
+            //at the moment, intentionally empty, this was created as part of patch to next system and not implemented yet
+            
+            //TODO:
+            //StartCoroutine(CompleteGameFlow());
+        }
+
         /// <summary>
         /// Call This when a checkpoint is reached, GFM will handle operation sequence.
         /// </summary>

--- a/Assets/Scripts/GameState/GameFlowManager.cs
+++ b/Assets/Scripts/GameState/GameFlowManager.cs
@@ -80,7 +80,7 @@ namespace GameState
 
         public void CompleteGame()
         {
-            Debug.LogError("Complete Game Is Empty : Not Written yet");
+            Debug.LogError("[Inquire with: Nico] Complete Game Is Empty : Not Written yet");
             //at the moment, intentionally empty, this was created as part of patch to next system and not implemented yet
             
             //TODO:

--- a/Assets/Scripts/TransitionAndResults/LevelCompletedUI.cs
+++ b/Assets/Scripts/TransitionAndResults/LevelCompletedUI.cs
@@ -123,8 +123,34 @@ namespace TransitionAndResults
 
         private void OnNextPressed()
         {
+            GameData data = GameStateManager.Instance.Data;
+
+            if (data.BeatGame)
+            {
+                FinalizeData();
+                GameFlowManager.Instance.CompleteGame();
+                return;
+            }
+
+            if (!TryGetNextLevel(data.CurrentLevel, out string nextLevel))
+            {
+                Debug.LogError($"[Inquire with Nico] Current level '{data.CurrentLevel}' not found in levelOrder list, no next level to be found.");
+                return;
+            }
+
+            // TryGetNextLevel was true at this point, null value means last level was completed
+            if (nextLevel == null)
+            {
+                data.BeatGame = true;
+                
+                FinalizeData();
+                GameFlowManager.Instance.CompleteGame();
+                return;
+            }
+
+            // nextLevel has a value, meaning start that level
             FinalizeData();
-            GameFlowManager.Instance.NewLevel("Level_04");
+            GameFlowManager.Instance.NewLevel(nextLevel);
         }
 
         private void FinalizeData()
@@ -155,6 +181,28 @@ namespace TransitionAndResults
 
             TextMeshProUGUI label = nextButton.GetComponentInChildren<TextMeshProUGUI>();
             label.text = beatGame ? "Game Scores" : "Next Level";
+        }
+
+        private static bool TryGetNextLevel(string currentLevel, out string nextLevel)
+        {
+            string[] order = GameStateManager.Instance.levelOrder;
+
+            int index = System.Array.IndexOf(order, currentLevel);
+            if (index < 0)
+            {
+                // current level was not in the level order array
+                nextLevel = null;
+                return false;
+            }
+
+            if (index + 1 >= order.Length)
+            {
+                nextLevel = null;
+                return true;
+            }
+            
+            nextLevel = order[index + 1];
+            return true;
         }
     }
 }


### PR DESCRIPTION
A Patch for the next button in CompleteLevelUI code. 

This will find the next level given context of the current level and start the loading of that next level

Will error report if the current level was not in level order array

will beat game and head into *STUBBED* Complete Game operation with GameFlowManager if the current level was the last in the level order array
- this stubbed operation not part of the patch, but coming soon